### PR TITLE
Update r9_trasos.csv

### DIFF
--- a/datasets/gov/vat/r9_trasos.csv
+++ b/datasets/gov/vat/r9_trasos.csv
@@ -5,7 +5,7 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
 ,,,,,,,,,,,,,,
 ,,,,Produktas,,,id,,,4,open,,"Pateikiama informacija apie produkto tipą, pavadinimą, galiojimo datą (ūkio subjekto pavadinimas, kontaktinė informacija)",
 ,,,,,id,string,,,,4,open,,Identifikacinis stulpelis,
-,,,,,kodas,ref,/datasets/gov/rc/jar/iregistruoti/JuridinisAsmuo,,,4,open,,Ūkio subjekto JAR kodas,
+,,,,,kodas,string,,,,2,open,,Ūkio subjekto JAR kodas,
 ,,,,,pavadinimas,string,,,,4,open,,Ūkio subjekto pavadinimas,
 ,,,,,pateikimas,date,D,,,4,open,,Pateikimo data,
 ,,,,,tel_nr,string,,,,1,open,,Ūkio subjektas telefono numeris,

--- a/datasets/gov/vat/r9_trasos.csv
+++ b/datasets/gov/vat/r9_trasos.csv
@@ -12,5 +12,5 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
 ,,,,,,comment,property,,"update(property: ""tel_nr[]"", type: ""array"", source: ""Tel_nr"")",1,,spinta:161,,
 ,,,,,email,string,,,,2,open,,Ūkio subjekto kontaktinis el. paštas,
 ,,,,,,comment,property,,"update(property: ""email[]"", type: ""array"", source: ""Email"")",4,,spinta:161,,
-,,,,,adresas,ref,/datasets/gov/rc/ar/adresotaskas/AdresoTaskas,,,3,open,,Ūkio subjekto adresas,
+,,,,,adresas,string,,,,2,open,,Ūkio subjekto adresas,
 ,,,,,trasa,string,,,,1,open,,Trąšos ir/arba dirvožemio gerinimo priemonės pavadinimas,


### PR DESCRIPTION
brandos lygis nuleistas iki 2, kadangi stulpelyje yra nelietuviškų JAR numerių ir null reikšmių. Dėl šios priežasties duomenų eksportas su ref'u į rc/jar/iregistruoti/JuridinisAsmuo būtų neįmanomas.