### PR TITLE
Iš patarles_priezodziai.csv pašalinti „ref“ tipą, kuris neveikia

### DIFF
--- a/datasets/gov/llti/patarles_priezodziai.csv
+++ b/datasets/gov/llti/patarles_priezodziai.csv
@@ -22,6 +22,6 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
 ,,,,,,comment,type,,"update(property: ""pastabos@lt"", type: ""text"")",4,open,spinta:204,,
 ,,,,,variantu_skaicius_orig,integer,,,,4,open,,Variantų originalus skaičius,
 ,,,,,variantu_skaicius,integer,,,,4,open,,Variantų atnaujintas skaičius,
-,,,,,tipo_id_nuoroda,ref,Tipas[tipo_id],,,4,open,,Išsamesnį aprašą turinčio panašaus tipo identifikatorius,
+,,,,,tipo_id_nuoroda,string,,,,4,open,,Išsamesnį aprašą turinčio panašaus tipo identifikatorius,
 ,,,,,susijusiu_tipu_id,string,,,,4,open,,Susijusių tipų identifikatoriai,
 ,,,,,savado_url,url,,,,4,open,,Žiniatinklio puslapis „Patarlių ir priežodžių elektroniniame sąvade“,


### PR DESCRIPTION
Lentelėje „Tipas“ stulpelis „tipo_id_nuoroda“ gali turėti (arba neturėti) nuorodos į tos pačios lentelės kitą stulpelį „tipo_id“ (tai yra pirminio rakto stulpelis). Dabar į spintą pavyksta įkelti tik tas eilutes, kuriose „tipo_id_nuoroda“ reikšmės yra tuščios.  Net jeigu bandome įkelti eilutę, kuri turi „tipo_id_nuoroda“ stulpelyje turi nuorodą į jau įkeltos kitos eilutės „tipo_id“, eksportavimas į spintą nulūžta:

> Your source responded to the REST request with an unexpected response code `400 `(see https://developer.mozilla.org/docs/Web/HTTP/Status/400) and the following message "`"errors":[{"type":"property","code":"InvalidRefValue","template":"Invalid reference value: {value}.","context":{"component":"spinta.components.Property","manifest":"default","schema":"39860","dataset":"datasets/gov/llti/patarles_priezodziai","model":"datasets/gov/llti/patarles_priezodziai/Tipas","entity":"","property":"tipo_id_nuoroda","attribute":"","value":"71010","id":"9e025845-2c36-4936-9ec2-d8f33b957d09"},"message":"Invalid reference value: 71010."}]}, filename=datasets_gov_llti_patarles_priezodziai_Tipas?#2025-01-15T08_25_35.051454877Z`". The expected response codes are `200, 201, 204`. Please troubleshoot this error with your REST source then try again.