### PR TITLE
patarles_priezodziai.csv tipo_id_noroda kaip string vietoj ref

### DIFF
--- a/datasets/gov/llti/patarles_priezodziai.csv
+++ b/datasets/gov/llti/patarles_priezodziai.csv
@@ -22,6 +22,6 @@ id,dataset,resource,base,model,property,type,ref,source,prepare,level,access,uri
 ,,,,,,comment,type,,"update(property: ""pastabos@lt"", type: ""text"")",4,open,spinta:204,,
 ,,,,,variantu_skaicius_orig,integer,,,,4,open,,Variantų originalus skaičius,
 ,,,,,variantu_skaicius,integer,,,,4,open,,Variantų atnaujintas skaičius,
-,,,,,tipo_id_nuoroda,ref,Tipas[tipo_id],,,4,open,,Išsamesnį aprašą turinčio panašaus tipo identifikatorius,
+,,,,,tipo_id_nuoroda,string,,,,4,open,,Išsamesnį aprašą turinčio panašaus tipo identifikatorius,
 ,,,,,susijusiu_tipu_id,string,,,,4,open,,Susijusių tipų identifikatoriai,
 ,,,,,savado_url,url,,,,4,open,,Žiniatinklio puslapis „Patarlių ir priežodžių elektroniniame sąvade“,


### PR DESCRIPTION
Įstaigai ištrynus lentelės įrašus, kyla bėdų pakeitimus nusiunčiant į Spintą: bando ištrinti įrašus, kurie susieti su kitais įrašais per nuorodą iš **tipo_id_noroda** į **tipo_id** stulpelį:
<img width="1297" height="193" alt="image" src="https://github.com/user-attachments/assets/b2925c4f-0d77-452f-a6be-fe15bfc90fbb" />

P.S. Praeityje eksportuojant įrašus irgi kilo panašių bėdų, tada irgi _tipo_id_noroda_ stulpeliui vietoj **ref** naudotas **string** (žr. https://github.com/atviriduomenys/manifest/pull/3993 ), bet sutvarkius perdavimą vėl buvo grąžintas į **ref** (žr. https://github.com/atviriduomenys/manifest/pull/4002 )